### PR TITLE
Package as Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1706234771,
+        "narHash": "sha256-mccsE0408Rbad2Alz4tzyxEqjyWhcBC6PWJY3GXspTQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6ce373f8ebee695e09af872200541fa61cdc6466",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "GUSbase";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+
+          GUSbase = with pkgs;
+            rPackages.buildRPackage {
+              name = "GUSbase";
+              src = ./.;
+              propagatedBuildInputs = with rPackages;
+                [ R6 Rdpack ggplot2 doParallel foreach data_table viridis network devtools ];
+            };
+
+          R-with-GUSbase = with pkgs;
+            rWrapper.override {
+              packages = with rPackages;
+                [ GUSbase ];
+            };
+        in
+          with pkgs;
+          {
+            devShells.default = mkShell {
+              buildInputs = [ R-with-GUSbase ];
+              shellHook = ''
+            mkdir -p "$(pwd)/_libs"
+            export R_LIBS_USER="$(pwd)/_libs"
+          '';
+            };
+
+            packages.default = GUSbase;
+          });
+}


### PR DESCRIPTION
Add Nix flake to enable local development and also downstream consumption of this R package as a Nix flake.

For the former, simply run `nix develop` in the repo root directory, which makes `R` available with `GUSbase` and its dependencies installed.

For an example of the latter, see the corresponding Nix Flake in [GUSMap](https://github.com/tpbilton/GUSMap).